### PR TITLE
修改支持直接绑定widget弹窗，同时支持透明度自定义

### DIFF
--- a/example/lib/drop_down_menu.dart
+++ b/example/lib/drop_down_menu.dart
@@ -2,15 +2,19 @@ import 'package:easy_popup/easy_popup.dart';
 import 'package:flutter/material.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 
-class DropDownMenu extends StatefulWidget with EasyPopupChild {
-  final _PopController controller = _PopController();
+class DropDownMenu extends StatefulWidget {
+  _DropDownMenuState _state;
+  final Key key;
+  DropDownMenu({this.key}): super(key: key);
 
   @override
-  _DropDownMenuState createState() => _DropDownMenuState();
+  _DropDownMenuState createState() {
+    _state = _DropDownMenuState();
+    return _state;
+  }
 
-  @override
   dismiss() {
-    controller.dismiss();
+    _state.dismiss();
   }
 }
 
@@ -21,8 +25,8 @@ class _DropDownMenuState extends State<DropDownMenu>
 
   @override
   void initState() {
+
     super.initState();
-    widget.controller._bindState(this);
     _controller = AnimationController(
       vsync: this,
       duration: Duration(milliseconds: 300),
@@ -38,8 +42,8 @@ class _DropDownMenuState extends State<DropDownMenu>
 
   @override
   void dispose() {
-    super.dispose();
     _controller?.dispose();
+    super.dispose();
   }
 
   @override
@@ -63,7 +67,7 @@ class _DropDownMenuState extends State<DropDownMenu>
                     behavior: HitTestBehavior.opaque,
                     onTap: () {
                       Fluttertoast.showToast(msg: 'item$index');
-                      EasyPopup.pop(context);
+                      Navigator.of(context).pop();
                     },
                     child: Container(
                       alignment: Alignment.center,
@@ -79,17 +83,5 @@ class _DropDownMenuState extends State<DropDownMenu>
         ),
       ),
     );
-  }
-}
-
-class _PopController {
-  _DropDownMenuState state;
-
-  _bindState(_DropDownMenuState state) {
-    this.state = state;
-  }
-
-  dismiss() {
-    state?.dismiss();
   }
 }

--- a/example/lib/guide_popup.dart
+++ b/example/lib/guide_popup.dart
@@ -1,7 +1,7 @@
 import 'package:easy_popup/easy_popup.dart';
 import 'package:flutter/material.dart';
 
-class GuidePopup extends StatefulWidget with EasyPopupChild {
+class GuidePopup extends StatefulWidget {
   final List<GlobalKey> highlightKeys;
 
   GuidePopup(this.highlightKeys);
@@ -9,8 +9,6 @@ class GuidePopup extends StatefulWidget with EasyPopupChild {
   @override
   _GuidePopupState createState() => _GuidePopupState();
 
-  @override
-  dismiss() {}
 }
 
 class _GuidePopupState extends State<GuidePopup> {

--- a/example/lib/home_page.dart
+++ b/example/lib/home_page.dart
@@ -97,8 +97,12 @@ class _HomeState extends State<Home> {
   }
 
   _showDropDownMenu() {
-    EasyPopup.show(context, DropDownMenu(),
-        offsetLT: Offset(0, MediaQuery.of(context).padding.top + 50));
+    DropDownMenu dropDownMenu = DropDownMenu();
+    EasyPopup.show(context, dropDownMenu,
+      offsetLT: Offset(0, MediaQuery.of(context).padding.top + 50),
+      onPopupDismiss: (){
+        dropDownMenu.dismiss();
+      });
   }
 
   _showLoading() {

--- a/example/lib/home_page.dart
+++ b/example/lib/home_page.dart
@@ -103,7 +103,9 @@ class _HomeState extends State<Home> {
 
   _showLoading() {
     EasyPopup.show(context, Loading(),
-        darkEnable: false, duration: Duration(milliseconds: 0));
+        // darkEnable: false,
+        opacity: 0,
+        duration: Duration(milliseconds: 0));
   }
 
   _showGuidePopup() {

--- a/example/lib/loading.dart
+++ b/example/lib/loading.dart
@@ -3,7 +3,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_spinkit/flutter_spinkit.dart';
 
-class Loading extends StatelessWidget with EasyPopupChild {
+class Loading extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Center(
@@ -20,7 +20,4 @@ class Loading extends StatelessWidget with EasyPopupChild {
       ),
     );
   }
-
-  @override
-  dismiss() {}
 }

--- a/lib/easy_popup.dart
+++ b/lib/easy_popup.dart
@@ -1,2 +1,1 @@
 export 'src/easy_popup.dart';
-export 'src/easy_popup_child.dart';

--- a/lib/src/easy_popup.dart
+++ b/lib/src/easy_popup.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 
-import 'easy_popup_child.dart';
 import 'easy_popup_route.dart';
 
 class EasyPopup {
@@ -12,13 +11,16 @@ class EasyPopup {
   ///Show popup
   static show(
     BuildContext context,
-    EasyPopupChild child, {
+    Widget child, {
     Offset offsetLT,
     Offset offsetRB,
     bool cancelable = true,
     bool outsideTouchCancelable = true,
-    bool darkEnable = true,
+    // bool darkEnable = true,
+    double opacity = 0.5,
     Duration duration = const Duration(milliseconds: 300),
+    VoidCallback onPopupShow,
+    VoidCallback onPopupDismiss,
     List<RRect> highlights,
   }) {
     Navigator.of(context).push(
@@ -28,8 +30,11 @@ class EasyPopup {
         offsetRB: offsetRB,
         cancelable: cancelable,
         outsideTouchCancelable: outsideTouchCancelable,
-        darkEnable: darkEnable,
+        // darkEnable: darkEnable,
+        opacity: opacity,
         duration: duration,
+        onPopupShow: onPopupShow,
+        onPopupDismiss: onPopupDismiss,
         highlights: highlights,
       ),
     );
@@ -40,3 +45,4 @@ class EasyPopup {
     EasyPopupRoute.setHighlights(context, highlights);
   }
 }
+

--- a/lib/src/easy_popup_child.dart
+++ b/lib/src/easy_popup_child.dart
@@ -1,5 +1,0 @@
-import 'package:flutter/material.dart';
-
-mixin EasyPopupChild implements Widget {
-  dismiss();
-}

--- a/lib/src/easy_popup_route.dart
+++ b/lib/src/easy_popup_route.dart
@@ -1,14 +1,15 @@
 import 'package:flutter/material.dart';
 
-import 'easy_popup_child.dart';
-
-class EasyPopupRoute extends PopupRoute {
-  final EasyPopupChild child;
+class EasyPopupRoute<T> extends PopupRoute<T> {
+  final Widget child;
   final Offset offsetLT, offsetRB;
   final Duration duration;
   final bool cancelable;
   final bool outsideTouchCancelable;
-  final bool darkEnable;
+  // final bool darkEnable;
+  final double opacity;
+  final VoidCallback onPopupShow;
+  final VoidCallback onPopupDismiss;
   final List<RRect> highlights;
 
   EasyPopupRoute({
@@ -17,10 +18,16 @@ class EasyPopupRoute extends PopupRoute {
     this.offsetRB,
     this.cancelable = true,
     this.outsideTouchCancelable = true,
-    this.darkEnable = true,
+    // this.darkEnable = true,
+    this.opacity = 0.5,
     this.duration = const Duration(milliseconds: 300),
+    this.onPopupShow,
+    this.onPopupDismiss,
     this.highlights,
-  });
+  }) {
+    assert(opacity != null && opacity <= 1.0 && opacity >= 0.0);
+    assert(duration != null);
+  }
 
   @override
   Color get barrierColor => null;
@@ -31,17 +38,34 @@ class EasyPopupRoute extends PopupRoute {
   @override
   String get barrierLabel => null;
 
+  GlobalKey<__PopRouteWidgetState> _globalKey = GlobalKey();
+  @override
+  bool didPop(T result) {
+    onPopupDismiss?.call();
+    _globalKey.currentState.dismiss();
+    return super.didPop(result);
+  }
+
+  @override
+  TickerFuture didPush() {
+    onPopupShow?.call();
+    return super.didPush();
+  }
+
   @override
   Widget buildPage(BuildContext context, Animation<double> animation,
       Animation<double> secondaryAnimation) {
     return _PopRouteWidget(
+      key: _globalKey,
       child: child,
       offsetLT: offsetLT,
       offsetRB: offsetRB,
       duration: duration,
+      // animation: animation,
       cancelable: cancelable,
       outsideTouchCancelable: outsideTouchCancelable,
-      darkEnable: darkEnable,
+      // darkEnable: darkEnable,
+      opacity: opacity,
       highlights: highlights,
     );
   }
@@ -49,8 +73,17 @@ class EasyPopupRoute extends PopupRoute {
   @override
   Duration get transitionDuration => duration;
 
+  // @override
+  // Animation<double> createAnimation() {
+  //   return CurvedAnimation(
+  //       parent: super.createAnimation(),
+  //       curve: Curves.linear//,
+  //       // reverseCurve: Curves.linear
+  //   );// const Interval(0.0, 2.0/3.0));
+  // }
+
   static pop(BuildContext context) {
-    __PopRouteWidgetState.of(context).dismiss();
+    // __PopRouteWidgetState.of(context).dismiss();
     Navigator.of(context).pop();
   }
 
@@ -60,45 +93,53 @@ class EasyPopupRoute extends PopupRoute {
 }
 
 class _PopRouteWidget extends StatefulWidget {
-  final EasyPopupChild child;
+  final Key key;
+  final Widget child;
   final Offset offsetLT, offsetRB;
   final Duration duration;
+  // final Animation<double> animation;
   final bool cancelable;
   final bool outsideTouchCancelable;
-  final bool darkEnable;
+  // final bool darkEnable;
+  final double opacity;
   final List<RRect> highlights;
 
+
   _PopRouteWidget({
+    this.key,
     this.child,
     this.offsetLT,
     this.offsetRB,
     this.duration,
+    // this.animation,
     this.cancelable,
     this.outsideTouchCancelable,
-    this.darkEnable,
+    // this.darkEnable,
+    this.opacity,
     this.highlights,
-  });
+  }):super(key: key);
 
   @override
   __PopRouteWidgetState createState() => __PopRouteWidgetState();
 }
 
 class __PopRouteWidgetState extends State<_PopRouteWidget>
-    with SingleTickerProviderStateMixin {
-  Animation<double> alphaAnim;
-  AnimationController alphaController;
+    with SingleTickerProviderStateMixin
+{
+  Animation<double> _alphaAnim;
+  AnimationController _alphaController;
   List<RRect> _highlights = [];
 
   @override
   void initState() {
     super.initState();
     highlights = widget.highlights ?? [];
-    alphaController = AnimationController(
+    _alphaController = AnimationController(
       vsync: this,
       duration: widget.duration,
     );
-    alphaAnim = Tween<double>(begin: 0, end: 127).animate(alphaController);
-    alphaController.forward();
+    _alphaAnim = Tween<double>(begin: 0, end: 255).animate(_alphaController);
+    _alphaController.forward();
   }
 
   static __PopRouteWidgetState of(BuildContext context) {
@@ -106,8 +147,7 @@ class __PopRouteWidgetState extends State<_PopRouteWidget>
   }
 
   dismiss() {
-    alphaController?.reverse();
-    widget.child?.dismiss();
+    _alphaController?.reverse();
   }
 
   set highlights(List<RRect> value) {
@@ -118,7 +158,7 @@ class __PopRouteWidgetState extends State<_PopRouteWidget>
 
   @override
   void dispose() {
-    alphaController?.dispose();
+    _alphaController?.dispose();
     super.dispose();
   }
 
@@ -127,7 +167,7 @@ class __PopRouteWidgetState extends State<_PopRouteWidget>
     return WillPopScope(
       onWillPop: () async {
         if (widget.cancelable) {
-          dismiss();
+          // dismiss();
           return true;
         }
         return false;
@@ -135,15 +175,15 @@ class __PopRouteWidgetState extends State<_PopRouteWidget>
       child: GestureDetector(
         onTap: () {
           if (widget.outsideTouchCancelable) {
-            dismiss();
+            // dismiss();
             Navigator.of(context).pop();
           }
         },
         child: Stack(
           children: <Widget>[
-            widget.darkEnable
+            widget.opacity != 0
                 ? AnimatedBuilder(
-                    animation: alphaController,
+                    animation: _alphaController , //widget.animation,
                     builder: (_, __) {
                       return Padding(
                         padding: EdgeInsets.only(
@@ -154,7 +194,7 @@ class __PopRouteWidgetState extends State<_PopRouteWidget>
                         ),
                         child: ColorFiltered(
                           colorFilter: ColorFilter.mode(
-                            Colors.black.withAlpha(alphaAnim.value.toInt()),
+                            Colors.black.withAlpha((_alphaAnim.value * widget.opacity).toInt()),
                             BlendMode.srcOut,
                           ),
                           child: Stack(


### PR DESCRIPTION
取消EasyPopupChild接口，通过设定onPopupDismiss来支持原有的EasyPopupChild接口中的dismiss功能，这样既可以通过自定义的widget来弹窗，页可以在需要弹窗的页绑定widget弹窗，可以方便弹出窗体的数据获取和交互。另增加onPopupShow在显示时的回调，同时修改darkEnable为opacity，以可以设定背景蒙版的透明度。